### PR TITLE
Tweak modals and default staff fields

### DIFF
--- a/AdminPage.js
+++ b/AdminPage.js
@@ -35,8 +35,8 @@ export default function AdminPage() {
   const [badge, setBadge] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const [nom, setNom] = useState('');
-  const [prenom, setPrenom] = useState('');
+  const [nom, setNom] = useState('El Bakkali');
+  const [prenom, setPrenom] = useState('Yahya');
   const [creating, setCreating] = useState(false);
   const [showUID, setShowUID] = useState({}); // toggle UID visibility per user
   const [showPassword, setShowPassword] = useState(false); // toggle password visibility
@@ -205,19 +205,24 @@ export default function AdminPage() {
             ) : staffUsers.length === 0 ? (
               <div>Aucun staff trouvé.</div>
             ) : (
-              <table className="w-full text-left text-gray-900 text-sm border-separate border-spacing-y-1">
-                <thead>
-                  <tr className="border-b border-gray-300">
-                    <th className="py-2 px-4">Badge</th>
-                    <th className="py-2 px-4">Firebase UID</th>
-                  </tr>
-                </thead>
-                <tbody>
+              <>
+              <div className="overflow-x-auto border border-[#ececec] bg-white animate-fadeIn rounded-none shadow-none">
+                <table className="min-w-full text-[15px] font-medium" style={{ fontFamily: 'Montserrat, Arial, sans-serif' }}>
+                  <thead>
+                    <tr
+                      className="font-bold uppercase text-xs tracking-wide select-none"
+                      style={{ background: '#C4002A', color: '#fff', userSelect: 'none', cursor: 'default' }}
+                    >
+                      <th className="px-4 py-3 text-left font-semibold whitespace-nowrap">Badge</th>
+                      <th className="px-4 py-3 text-left font-semibold whitespace-nowrap">Firebase UID</th>
+                    </tr>
+                  </thead>
+                  <tbody>
                   {paginatedStaff.map(u => (
                     <tr
                       key={u.uid}
-                      className="hover:bg-gray-100 cursor-default rounded"
-                      style={{ transition: "background-color 0.3s" }}
+                      className="border-b border-[#ececec] bg-white hover:bg-[#F8E6EA]/55 cursor-default transition-colors"
+                      style={{ transition: 'background 0.14s cubic-bezier(0.23, 1, 0.32, 1)' }}
                     >
                       <td className="py-2 px-4 truncate">{u.badge || u.email?.split('@')[0]}</td>
                       <td className="py-2 px-4 font-mono text-xs select-all relative">
@@ -240,8 +245,9 @@ export default function AdminPage() {
                       </td>
                     </tr>
                   ))}
-                </tbody>
-              </table>
+                  </tbody>
+                </table>
+              </div>
               <div className="flex justify-center items-center mt-4 gap-2">
                 <button
                   onClick={() => setStaffPage(p => Math.max(1, p - 1))}
@@ -263,6 +269,7 @@ export default function AdminPage() {
                   <ChevronRightIcon className="h-5 w-5 ml-1 text-ramRed" />
                 </button>
               </div>
+              </>
             )}
           </section>
 
@@ -274,21 +281,26 @@ export default function AdminPage() {
             ) : normalUsers.length === 0 ? (
               <div>Aucun utilisateur trouvé.</div>
             ) : (
-              <table className="w-full text-left text-gray-900 text-sm border-separate border-spacing-y-1">
-                <thead>
-                  <tr className="border-b border-gray-300">
-                    <th className="py-2 px-4">Prénom</th>
-                    <th className="py-2 px-4">Nom</th>
-                    <th className="py-2 px-4">Email</th>
-                    <th className="py-2 px-4">Firebase UID</th>
-                  </tr>
-                </thead>
-                <tbody>
+              <>
+              <div className="overflow-x-auto border border-[#ececec] bg-white animate-fadeIn rounded-none shadow-none">
+                <table className="min-w-full text-[15px] font-medium" style={{ fontFamily: 'Montserrat, Arial, sans-serif' }}>
+                  <thead>
+                    <tr
+                      className="font-bold uppercase text-xs tracking-wide select-none"
+                      style={{ background: '#C4002A', color: '#fff', userSelect: 'none', cursor: 'default' }}
+                    >
+                      <th className="px-4 py-3 text-left font-semibold whitespace-nowrap">Prénom</th>
+                      <th className="px-4 py-3 text-left font-semibold whitespace-nowrap">Nom</th>
+                      <th className="px-4 py-3 text-left font-semibold whitespace-nowrap">Email</th>
+                      <th className="px-4 py-3 text-left font-semibold whitespace-nowrap">Firebase UID</th>
+                    </tr>
+                  </thead>
+                  <tbody>
                   {paginatedUsers.map(u => (
                     <tr
                       key={u.uid}
-                      className="hover:bg-gray-100 cursor-default rounded"
-                      style={{ transition: "background-color 0.3s" }}
+                      className="border-b border-[#ececec] bg-white hover:bg-[#F8E6EA]/55 cursor-default transition-colors"
+                      style={{ transition: 'background 0.14s cubic-bezier(0.23, 1, 0.32, 1)' }}
                     >
                       <td className="py-2 px-4">{u.prenom}</td>
                       <td className="py-2 px-4">{u.nom}</td>
@@ -313,8 +325,9 @@ export default function AdminPage() {
                       </td>
                     </tr>
                   ))}
-                </tbody>
-              </table>
+                  </tbody>
+                </table>
+              </div>
               <div className="flex justify-center items-center mt-4 gap-2">
                 <button
                   onClick={() => setUserPage(p => Math.max(1, p - 1))}
@@ -336,6 +349,7 @@ export default function AdminPage() {
                   <ChevronRightIcon className="h-5 w-5 ml-1 text-ramRed" />
                 </button>
               </div>
+              </>
             )}
           </section>
         </FadeInDiv>
@@ -351,8 +365,8 @@ export default function AdminPage() {
           </button>
         </FadeInDiv>
         {openModal && (
-          <div className="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50">
-            <div className="bg-white rounded-md w-full max-w-sm p-6 max-h-[85vh] overflow-auto">
+          <div className="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50 animate-fadeIn">
+            <div className="bg-white rounded-lg shadow-lg w-full max-w-lg p-8 max-h-[90vh] overflow-auto animate-fadeInUp">
               <div className="flex justify-between items-center mb-4">
                 <h2 className="text-lg font-semibold text-ramRed">Créer un compte Staff</h2>
                 <button type="button" onClick={() => setOpenModal(false)} aria-label="Fermer" className="text-gray-400 hover:text-gray-600">

--- a/DetailBagagePage.js
+++ b/DetailBagagePage.js
@@ -48,8 +48,8 @@ export default function DetailBagagePage() {
 
 
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-start justify-center p-4 z-50" style={{ fontFamily: 'Montserrat, Arial, sans-serif' }}>
-      <div className="bg-white rounded-md w-full max-w-lg mx-auto overflow-auto" style={{ maxHeight: '90vh' }}>
+    <div className="fixed inset-0 bg-black/40 flex items-start justify-center p-4 z-50 animate-fadeIn" style={{ fontFamily: 'Montserrat, Arial, sans-serif' }}>
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-2xl mx-auto overflow-auto p-8 animate-fadeInUp" style={{ maxHeight: '90vh' }}>
         <div className="flex items-center justify-between px-7 pt-6 pb-2 border-b" style={{ borderBottom: '1.5px solid #ececec' }}>
           <h1 className="text-[1.12rem] font-bold text-[#C4002A] tracking-tight uppercase" style={{ letterSpacing: '0.7px' }}>
             Détail du bagage


### PR DESCRIPTION
## Summary
- prefill staff name fields
- enlarge staff creation modal with fade in effect
- enlarge baggage detail modal and add animation

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_684314c2faa4832fb86ea2f54cfae7ca